### PR TITLE
Update workflow to only do stable charts for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         with:
-          charts_dir: charts
+          charts_dir: charts/stable
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Currently I haven't found a way to deploy both stable and incubator charts, so instead I will just deploy stable for the time being.